### PR TITLE
UUID for Mail 12.4 on 10.14.6 (18G103)

### DIFF
--- a/AltPlugin.mailbundle/Contents/Info.plist
+++ b/AltPlugin.mailbundle/Contents/Info.plist
@@ -63,6 +63,8 @@
 		<string>C86CD990-4660-4E36-8CDA-7454DEB2E199</string>
 		<string># For mail version 11.5 (3445.9.1) on OS X Version 10.13.6 (build 17G65)</string>
 		<string>C86CD990-4660-4E36-8CDA-7454DEB2E199</string>
+		<string># For mail version 12.4 (3445.104.11) on OS X Version 10.14.6 (build 18G103)</string>
+		<string>A4343FAF-AE18-40D0-8A16-DFAE481AF9C1</string>
 		<string># For mail version 13.0 (3594.4.2) on OS X Version 10.15 (build 19A558d)</string>
 		<string>6EEA38FB-1A0B-469B-BB35-4C2E0EEA9053</string>
 	</array>


### PR DESCRIPTION
Resolves https://github.com/pixelomer/AltDeploy/issues/1 (some users having this issue on Mojave with Mail 12.4).